### PR TITLE
fix: replace deprecated char_at with get_char().unwrap()

### DIFF
--- a/src/vlq.mbt
+++ b/src/vlq.mbt
@@ -84,7 +84,7 @@ fn encode_single_to_base64_vlq(number : Int) -> String {
     if vlq > 0 {
       digit = digit | 0b100000
     }
-    encoded = encoded + BASE64_CHARS.char_at(digit).to_string()
+    encoded = encoded + BASE64_CHARS.get_char(digit).unwrap().to_string()
   }
   encoded
 }
@@ -126,7 +126,7 @@ pub fn from_base64_vlq(s : String) -> Array[Int] raise VlqError {
     let mut continuation = true
     while continuation {
       guard i < len else { raise IncompleteSequence }
-      let char = s.char_at(i)
+      let char = s.get_char(i).unwrap()
       i = i + 1
       match get_base64_map().get(char) {
         None => raise InvalidBase64Character(char)

--- a/src/vlq.mbti
+++ b/src/vlq.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "CAIMEOX/vlq"
 
 // Values
@@ -9,7 +10,7 @@ fn to_base64_vlq(Array[Int]) -> String
 
 fn to_vlq(Array[UInt]) -> Array[Byte]
 
-// Types and methods
+// Errors
 pub(all) suberror VlqError {
   Overflow
   IncompleteSequence
@@ -17,6 +18,8 @@ pub(all) suberror VlqError {
 }
 impl Eq for VlqError
 impl Show for VlqError
+
+// Types and methods
 
 // Type aliases
 


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

This commit fixes all compiler warnings by replacing the deprecated char_at method calls with the recommended get_char(i).unwrap() approach in the VLQ implementation.